### PR TITLE
Make go:linkname work for other architectures

### DIFF
--- a/sleep/dummy.s
+++ b/sleep/dummy.s
@@ -1,0 +1,18 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This empty assembly file is here to make the sure there is always an
+// assembly file included also for architectures for which there are no
+// other .s files. This is required to make the //go:linkname directive
+// work.


### PR DESCRIPTION
Add an empty assembly file to make the go:linkname directive
work on other architectures than those that have .s files
included.

Without this I get:
```
netstack\sleep\sleep_unsafe.go:88:6: missing function body
netstack\sleep\sleep_unsafe.go:91:6: missing function body
```