### PR TITLE
add support for icmp

### DIFF
--- a/tcpip/transport/icmp/endpoint.go
+++ b/tcpip/transport/icmp/endpoint.go
@@ -709,3 +709,9 @@ func (e *endpoint) HandlePacket(r *stack.Route, id stack.TransportEndpointID, vv
 // HandleControlPacket implements stack.TransportEndpoint.HandleControlPacket.
 func (e *endpoint) HandleControlPacket(id stack.TransportEndpointID, typ stack.ControlType, extra uint32, vv buffer.VectorisedView) {
 }
+
+// State implements tcpip.Endpoint.State. The ICMP endpoint currently doesn't
+// expose internal socket state.
+func (e *endpoint) State() uint32 {
+	return 0
+}

--- a/tcpip/transport/icmp/endpoint.go
+++ b/tcpip/transport/icmp/endpoint.go
@@ -658,13 +658,12 @@ func (e *endpoint) HandlePacket(r *stack.Route, id stack.TransportEndpointID, vv
 	// Only accept echo replies.
 	switch e.netProto {
 	case header.IPv4ProtocolNumber:
-	//	h := header.ICMPv4(vv.First())
-	/*	if h.Type() != header.ICMPv4EchoReply && h.Type() != header.ICMPv4Echo {
-		typea := h.Type()
-		log.Printf("type:%v", string(typea))
-		e.stack.Stats().DroppedPackets.Increment()
-		return
-	}*/
+		h := header.ICMPv4(vv.First())
+		if h.Type() != header.ICMPv4EchoReply && h.Type() != header.ICMPv4Echo {
+			typea := h.Type()
+			e.stack.Stats().DroppedPackets.Increment()
+			return
+		}
 	case header.IPv6ProtocolNumber:
 		h := header.ICMPv6(vv.First())
 		if h.Type() != header.ICMPv6EchoReply {

--- a/tcpip/transport/icmp/endpoint.go
+++ b/tcpip/transport/icmp/endpoint.go
@@ -660,7 +660,6 @@ func (e *endpoint) HandlePacket(r *stack.Route, id stack.TransportEndpointID, vv
 	case header.IPv4ProtocolNumber:
 		h := header.ICMPv4(vv.First())
 		if h.Type() != header.ICMPv4EchoReply && h.Type() != header.ICMPv4Echo {
-			typea := h.Type()
 			e.stack.Stats().DroppedPackets.Increment()
 			return
 		}

--- a/tcpip/transport/icmp/forwarder.go
+++ b/tcpip/transport/icmp/forwarder.go
@@ -1,0 +1,97 @@
+// Copyright 2019 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package icmp
+
+import (
+	"github.com/google/netstack/tcpip"
+	"github.com/google/netstack/tcpip/buffer"
+	"github.com/google/netstack/tcpip/stack"
+	"github.com/google/netstack/waiter"
+)
+
+// Forwarder is a session request forwarder, which allows clients to decide
+// what to do with a session request, for example: ignore it, or process it.
+//
+// The canonical way of using it is to pass the Forwarder.HandlePacket function
+// to stack.SetTransportProtocolHandler.
+type Forwarder struct {
+	handler func(*ForwarderRequest)
+
+	stack *stack.Stack
+}
+
+// NewForwarder allocates and initializes a new forwarder.
+func NewForwarder(s *stack.Stack, handler func(*ForwarderRequest)) *Forwarder {
+	return &Forwarder{
+		stack:   s,
+		handler: handler,
+	}
+}
+
+// HandlePacket handles all packets.
+//
+// This function is expected to be passed as an argument to the
+// stack.SetTransportProtocolHandler function.
+func (f *Forwarder) HandlePacket(r *stack.Route, id stack.TransportEndpointID, netHeader buffer.View, vv buffer.VectorisedView) bool {
+
+	f.handler(&ForwarderRequest{
+		stack: f.stack,
+		route: r,
+		id:    id,
+		vv:    vv,
+	})
+
+	return true
+}
+
+// ForwarderRequest represents a session request received by the forwarder and
+// passed to the client. Clients may optionally create an endpoint to represent
+// it via CreateEndpoint.
+type ForwarderRequest struct {
+	stack *stack.Stack
+	route *stack.Route
+	id    stack.TransportEndpointID
+	vv    buffer.VectorisedView
+}
+
+// ID returns the 4-tuple (src address, src port, dst address, dst port) that
+// represents the session request.
+func (r *ForwarderRequest) ID() stack.TransportEndpointID {
+	return r.id
+}
+
+// CreateEndpoint creates a connected UDP endpoint for the session request.
+func (r *ForwarderRequest) CreateEndpoint(queue *waiter.Queue) (tcpip.Endpoint, *tcpip.Error) {
+	ep, _ := newEndpoint(r.stack, r.route.NetProto, ProtocolNumber4, queue)
+	if err := r.stack.RegisterTransportEndpoint(r.route.NICID(), []tcpip.NetworkProtocolNumber{r.route.NetProto}, ProtocolNumber4, r.id, ep, true); err != nil {
+		ep.Close()
+		return nil, err
+	}
+
+	ep.id = r.id
+	ep.route = r.route.Clone()
+	//	ep.dstPort = r.id.RemotePort
+	ep.regNICID = r.route.NICID()
+
+	ep.state = stateConnected
+
+	ep.rcvMu.Lock()
+	ep.rcvReady = true
+	ep.rcvMu.Unlock()
+
+	ep.HandlePacket(r.route, r.id, r.vv)
+
+	return ep, nil
+}


### PR DESCRIPTION
Now the icmp endpoint in the transport folder has no public function to call, so I added a forward.go file to the udp package. In the process I found that the return value of newEndPoint should be *endpoint instead of tcpip.EndPoint, otherwise the RegisterTransportEndpoint will pass. The return value obtained by newEndpoint cannot be passed in. It will prompt cannot use ep (type tcpip.Endpoint) as type stack.TransportEndpoint in argument to r.stack.RegisterTransportEndpoint